### PR TITLE
feat(build-tools): add option to ignore exit status of cmds

### DIFF
--- a/packages/build-tools/pkg/buildsys/parser.go
+++ b/packages/build-tools/pkg/buildsys/parser.go
@@ -219,7 +219,7 @@ func task(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kw
 
 	err := starlark.UnpackArgs(fn.Name(), args, kwargs, "short??", &task.Short, "hidden?", &task.Hidden,
 		"desc?", &task.Desc, "deps?", &deps, "base?", &task.Base, "skip_if_exists?", &skipIfExists, "inputs?",
-		&inputs, "outputs?", &outputs, "env?", &env, "cmds?", &cmds)
+		&inputs, "outputs?", &outputs, "env?", &env, "cmds?", &cmds, "ignore_exit?", &task.IgnoreExit)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/build-tools/pkg/buildsys/types.go
+++ b/packages/build-tools/pkg/buildsys/types.go
@@ -58,6 +58,7 @@ type Task struct {
 	SkipIfExists []string
 	Outputs      []string
 	Cmds         []TaskCmd
+	IgnoreExit   bool
 	Hidden       bool
 }
 


### PR DESCRIPTION
It was pointed out to me that you can just `set +e`... Nonetheless, I think this
approach also has some merit. Give it a look.
