### PR TITLE
fix(ci): linking on linux

### DIFF
--- a/packages/build-tools/pkg/buildsys/parser.go
+++ b/packages/build-tools/pkg/buildsys/parser.go
@@ -366,23 +366,35 @@ func RunScript(ctx context.Context, filename, projectRoot string, options map[st
 	}
 
 	builtins := starlark.StringDict{
-		"OS":           starlark.String(runtime.GOOS),
-		"ARCH":         starlark.String(runtime.GOARCH),
-		"info":         starlark.NewBuiltin("info", starInfo),
-		"warn":         starlark.NewBuiltin("warn", starWarn),
-		"error":        starlark.NewBuiltin("error", starError),
+		// global constants
+		"OS":   starlark.String(runtime.GOOS),
+		"ARCH": starlark.String(runtime.GOARCH),
+
+		// log outputs
+		"info":  starlark.NewBuiltin("info", starInfo),
+		"warn":  starlark.NewBuiltin("warn", starWarn),
+		"error": starlark.NewBuiltin("error", starError),
+
+		// FS helpers
 		"resolve_path": starlark.NewBuiltin("resolve_path", resolvePath),
 		"to_slashes":   starlark.NewBuiltin("to_slashes", toSlashes),
-		"option":       starlark.NewBuiltin("option", option),
+		"isdir":        starlark.NewBuiltin("isdir", starIsdir),
+		"isfile":       starlark.NewBuiltin("isfile", starIsfile),
+		"read_yaml":    starlark.NewBuiltin("read_yaml", readYaml),
+		"execute":      starlark.NewBuiltin("execute", starExec),
+
+		// env handling
 		"getenv":       starlark.NewBuiltin("getenv", getenv),
 		"setenv":       starlark.NewBuiltin("setenv", setenv),
 		"prepend_path": starlark.NewBuiltin("prepend_path", prependPathDir),
-		"read_yaml":    starlark.NewBuiltin("read_yaml", readYaml),
-		"isdir":        starlark.NewBuiltin("isdir", starIsdir),
-		"isfile":       starlark.NewBuiltin("isfile", starIsfile),
-		"execute":      starlark.NewBuiltin("execute", starExec),
-		"task":         starlark.NewBuiltin("task", task),
-		"load_vcvars":  starlark.NewBuiltin("load_vcvars", starLoadVcvars),
+
+		// buildsys stuff
+		"option": starlark.NewBuiltin("option", option),
+		"task":   starlark.NewBuiltin("task", task),
+
+		// OS / compiler helpers
+		"load_vcvars": starlark.NewBuiltin("load_vcvars", starLoadVcvars),
+		"lookup_lib":  starlark.NewBuiltin("lookup_lib", starLookupLib),
 	}
 
 	thread := &starlark.Thread{

--- a/packages/libarchive/handle.go
+++ b/packages/libarchive/handle.go
@@ -3,21 +3,6 @@ package libarchive
 // #cgo CFLAGS: -I${SRCDIR}/../../third_party/libarchive
 // #cgo LDFLAGS: -L${SRCDIR}/../../build/libarchive/libarchive
 //
-// // platform specific filename for libarchive
-// #cgo windows LDFLAGS: ${SRCDIR}/../../build/libarchive/libarchive/libarchive_static.a
-// #cgo linux   LDFLAGS: ${SRCDIR}/../../build/libarchive/libarchive/libarchive.a
-// #cgo darwin  LDFLAGS: ${SRCDIR}/../../build/libarchive/libarchive/libarchive.a
-//
-// // look for liblzma in the lib directory from homebrew's xz package
-// #cgo darwin  LDFLAGS: -L/usr/local/opt/xz/lib
-//
-// // darwin's ld doesn't understand --no-undefined so skip it there
-// // linux doesn't need iconv since it's part of glibc
-// #cgo windows LDFLAGS: -Wl,--no-undefined -liconv
-// #cgo linux   LDFLAGS: -Wl,--no-undefined
-// #cgo darwin  LDFLAGS: -liconv
-// #cgo         LDFLAGS: -llzma -lzstd -lz
-//
 // #include <stdlib.h>
 // #include <libarchive/archive.h>
 // #include <libarchive/archive_entry.h>

--- a/tasks.star
+++ b/tasks.star
@@ -40,7 +40,10 @@ Task help:
 """
 
 build = option("build", "Release", help = "Whether to build a Debug or Release build")
-libkn_static = option("static", "true", help = "Whether to statically or dynamically link libknossos")
+if OS == "windows":
+    libkn_static = option("static", "true", help = "Whether to statically or dynamically link libknossos")
+else:
+    libkn_static = ""
 
 msys2_path = option("msys2_path", "//third_party/msys64", help = "The path to your MSYS2 installation. Only used on Windows. " +
                                                                  "Defaults to the bundled MSYS2 directory")
@@ -498,7 +501,7 @@ def configure():
     )
 
     libkn_ldflags = ""
-    if libkn_static == "true" and OS != "darwin":
+    if libkn_static == "true":
         libkn_ldflags += "-static "
 
     # platform specific filename for libarchive

--- a/tasks.star
+++ b/tasks.star
@@ -40,15 +40,11 @@ Task help:
 """
 
 build = option("build", "Release", help = "Whether to build a Debug or Release build")
-if OS == "windows":
-    libkn_static = option("static", "true", help = "Whether to statically or dynamically link libknossos")
-else:
-    libkn_static = ""
-
+libkn_static = option("static", "true", help = "Whether to statically or dynamically link libknossos (only Windows)")
 msys2_path = option("msys2_path", "//third_party/msys64", help = "The path to your MSYS2 installation. Only used on Windows. " +
                                                                  "Defaults to the bundled MSYS2 directory")
 generator_opt = option("generator", "", help = "The CMake generator to use. Defaults to ninja if available. " +
-                                               "Please note that on Windows you'll  have to run the vcvarsall.bat if you don't choose a Visual Studio generator")
+                                               "Please note that on Windows you'll have to run the vcvarsall.bat if you don't choose a Visual Studio generator")
 
 db_network = option("db_network", "nebula", help = "The name of the Docker network to use for Nebula-related containers.")
 db_container = option("db_container", "nebula-db", help = "The name of the Docker container for Nebula's managed database.")

--- a/tasks.star
+++ b/tasks.star
@@ -40,7 +40,7 @@ Task help:
 """
 
 build = option("build", "Release", help = "Whether to build a Debug or Release build")
-libkn_static = option("static", "true", help = "Whether to statically or dynamically link libknossos (only Windows)")
+libkn_static = option("static", "true" if OS == "windows" else "false", help = "Whether to statically or dynamically link libknossos (only Windows)")
 msys2_path = option("msys2_path", "//third_party/msys64", help = "The path to your MSYS2 installation. Only used on Windows. " +
                                                                  "Defaults to the bundled MSYS2 directory")
 generator_opt = option("generator", "", help = "The CMake generator to use. Defaults to ninja if available. " +
@@ -151,7 +151,7 @@ def find_static_lib(names, display_name = None):
         display_name = names[0]
 
     for name in names:
-        so_path = lookup_lib(name)
+        so_path = lookup_lib(name + ".so")
         if so_path:
             a_path = so_path.replace(".so", ".a")
             if isfile(a_path):
@@ -518,8 +518,8 @@ def configure():
         libkn_ldflags += " -liconv -llzma -lzstd -lz"
     else:
         libkn_ldflags += " " + " ".join([
-            find_static_lib(["lzma"]),
-            find_static_lib(["zstd"]),
+            find_static_lib(["liblzma"]),
+            find_static_lib(["libzstd"]),
             find_static_lib(["libz", "zlib"]),
         ])
 


### PR DESCRIPTION
This change moves LDFLAGS management from CGo to tasks.star. It also explicitly uses static libraries instead of leaving it up to the linker. This should statically link specific libraries which might not be available everywhere while dynamically linking against system libraries like glibc.