### PR TITLE
Minor update to `More...` list

### DIFF
--- a/packages/client-ui/src/pages/local-mod-list.tsx
+++ b/packages/client-ui/src/pages/local-mod-list.tsx
@@ -132,7 +132,7 @@ function ModActionMenu(props: { mod: SimpleModList_Item }): React.ReactElement {
             <MenuItem
               key={tool.label}
               icon="play"
-              text={'Open ' + tool.label}
+              text={'Run ' + tool.label}
               onClick={() =>
                 gs.launchOverlay(LaunchModDialog, {
                   modid: props.mod.modid,

--- a/packages/libknossos/pkg/twirp/mods.go
+++ b/packages/libknossos/pkg/twirp/mods.go
@@ -251,6 +251,9 @@ func (kn *knossosServer) GetModInfo(ctx context.Context, req *client.ModInfoRequ
 					}
 				}
 			}
+			sort.SliceStable(tools, func(i, j int) bool {
+				return tools[i].Label < tools[j].Label
+			})
 		} else {
 			api.Log(ctx, api.LogWarn, "Could not resolve engine for mod %s (%s): %s", mod.Title, release.Version, eris.ToString(err, true))
 		}


### PR DESCRIPTION
This PR adds a two minor updates to list of options that appears when the `More...` button is clicked on a mod.

1) Changes the word `Open` to the word `Run`. This seems minor, but IMO really helps with clarifying difference between running an exe (FRED, Fast Debug) and opening the log file.

2) Sorts the list of options to this order "FRED2, FRED2 Debug, Fast Debug, QtFRED, qtFRED Debug, Open Debug Log, Verify File Integrity".  Works out that this order is a logical and also alphabetical. Previous ordering was "FRED2 Debug, FRED2, Fast Debug, qtFRED Debug, QtFRED, Open Debug Log, Verify File Integrity."