### PR TITLE
Enable Screenshots Folder Button

### DIFF
--- a/packages/api/definitions/client.proto
+++ b/packages/api/definitions/client.proto
@@ -383,4 +383,5 @@ service Knossos {
   rpc UpdateLocalModList (TaskRequest) returns (SuccessResponse) {};
   rpc OpenDebugLog (NullMessage) returns (TaskResult) {};
   rpc VerifyChecksums (VerifyChecksumRequest) returns (SuccessResponse) {};
+  rpc OpenScreenshotsFolder (NullMessage) returns (TaskResult) {};
 }

--- a/packages/client-ui/src/elements/root.tsx
+++ b/packages/client-ui/src/elements/root.tsx
@@ -23,6 +23,7 @@ import RemoteModList from '../pages/remote-mod-list';
 import Settings from '../pages/settings';
 import LocalMod from '../pages/local-mod';
 import RemoteMod from '../pages/remote-mod';
+import { maybeError } from '../dialogs/error-dialog';
 
 const NavTabs = function NavTabs(): React.ReactElement {
   const navigate = useNavigate();
@@ -198,7 +199,7 @@ export default function Root(): React.ReactElement {
           <TooltipButton tooltip="Refresh Mod List" onClick={() => void refreshModList(gs)}>
             <CiRefreshLine />
           </TooltipButton>
-          <TooltipButton tooltip="Screenshots">
+          <TooltipButton tooltip="Screenshots" onClick={() => maybeError(gs, gs.client.openScreenshotsFolder({}))}>
             <CiPictureLine className="ml-2" />
           </TooltipButton>
           <CiFilterLine className="ml-2" />

--- a/packages/libknossos/pkg/twirp/mods.go
+++ b/packages/libknossos/pkg/twirp/mods.go
@@ -442,3 +442,20 @@ func (kn *knossosServer) VerifyChecksums(ctx context.Context, req *client.Verify
 
 	return &client.SuccessResponse{Success: true}, nil
 }
+
+func (kn *knossosServer) OpenScreenshotsFolder(ctx context.Context, req *client.NullMessage) (*client.TaskResult, error) {
+	prefPath := fsointerop.GetPrefPath(ctx)
+	logPath := filepath.Join(prefPath, "data", "screenshots")
+
+	_, err := os.Stat(logPath)
+	if eris.Is(err, os.ErrNotExist) {
+		return &client.TaskResult{Error: fmt.Sprintf("Could not find %s", logPath)}, nil
+	}
+
+	err = platform.OpenLink(logPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &client.TaskResult{Success: true}, nil
+}


### PR DESCRIPTION
Clicking the `Screenshots` button now opens the `screenshots` folder. Tested and works as expected. 